### PR TITLE
fix: try to split listings table into two parts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -282,6 +282,9 @@ main.pdf
 *.plf
 *.plt
 
+# Appendix listings
+*.apl
+
 # REVTeX puts footnotes in the bibliography by default, unless the nofootinbib
 # option is specified. Footnotes are the stored in a file with suffix Notes.bib.
 # Uncomment the next line to have this generated file ignored.

--- a/commonPreamble.sty
+++ b/commonPreamble.sty
@@ -253,6 +253,40 @@ literate=%
 \renewcommand{\appendixtocname}{Annexes}
 \renewcommand{\setthesection}{\Alph{section}}
 
+% Pour avoir une table de listings dans les annexes
+\makeatletter
+
+  \providecommand{\phantomsection}{}
+  % Pour modifier plus facilement le nom - Ici, je recycles ceux de base
+  \newcommand\appendixlistingname{\lstlistlistingname}
+  \newcommand{\listofappendixlistings}{%
+  % Applying the same trick as listings does with \lstlistoflistings: Modifying \@starttoc such that it can load only .apl files
+    \begingroup
+      \let\@starttoc@orig\@starttoc%
+      \renewcommand{\contentsname}{\appendixlistingname}
+      \renewcommand{\@starttoc}[1]{%
+        \@starttoc@orig{apl}%
+      }%    
+      \phantomsection
+      \addcontentsline{toc}{section}{\appendixlistingname}
+      \tableofcontents% Calling \tableofcontents with the `.apl` file instead of `.toc`
+    \endgroup
+  }
+
+  \newcommand{\appendixFix}{%
+  \setcounter{lstlisting}{0}%
+  \@ifundefined{theHlstlisting}{%
+    }{%
+      \renewcommand{\theHlstlisting}{appendix}
+    }%
+  \write\@auxout{%
+    \string\let\string\latex@tf@lol\string\tf@lol% Store the original `\tf@lol` file handle
+    \string\let\string\tf@lol\string\tf@apl% 
+  }%
+}{}{}
+
+\makeatother
+
 % Pour ignorer des figures / tables des tables
 % C'est uniquement pour les annexes, pour ne pas polluer le tout
 % \captionsetup{list=no} pour cacher

--- a/sections/annexes/index.tex
+++ b/sections/annexes/index.tex
@@ -1,16 +1,16 @@
 % On imprime une table des figures / tables pour mieux naviguer ici
 \begingroup
     \let\clearpage\relax
-    % prints main list of figures
+    % prints appendices list of figures
     \printlist[appendices]{lof}{}{
         \chapter*{\listfigurenameappendixes}
     }
-    % prints main list of tables
+    % prints appendices list of tables
     \printlist[appendices]{lot}{}{
         \chapter*{\listtablenameappendixes}
     }
-    % TODO trouver un moyen de restreindre celui-là
-    %\lstlistoflistings
+    % prints appendices list of tables listings
+    \listofappendixlistings
 \endgroup
 
 \import{sections/annexes/problematique/}{index}

--- a/structure.tex
+++ b/structure.tex
@@ -45,7 +45,7 @@
 
 % Stop partial lists
 \stoplist[main]{lof}% stops main list of figures
-\stoplist[main]{lot}% stops main list of figures
+\stoplist[main]{lot}% stops main list of tables
 
 % juste avant la bibliographie et les annexes
 \backmatter
@@ -61,6 +61,9 @@
 \newcommand\listfigurenameappendixes{\listfigurename}
 \newcommand\listtablenameappendixes{\listtablename}
 
+% Pour marquer la séparation avec les extraits de code des annexes
+\appendixFix
+
 % Annexes
 % Explications : https://texfaq.org/FAQ-appendix
 \begin{appendices}
@@ -69,4 +72,4 @@
 
 % Stop partial lists
 \stoplist[appendices]{lof}% stops main list of figures
-\stoplist[appendices]{lot}% stops main list of figures
+\stoplist[appendices]{lot}% stops main list of tables


### PR DESCRIPTION
Split listings table into two parts (not-appendix and appendix)
@dewita As it works on the workflow, It should work on your laptop : can you confirm me that ?