### PR TITLE
fix: replace SourceCode by Source Code

### DIFF
--- a/sections/chapters/analyseCritique/index.tex
+++ b/sections/chapters/analyseCritique/index.tex
@@ -1,7 +1,7 @@
 \chapter{Analyse critique}
 \label{section:validation}
 
-Dans ce chapitre-ci, nous nous efforçons d'avoir un regard critique sur \texttt{SourceCode}. Par la validation du projet (test avec des utilisateurs externes, test de la qualité du code) et les différentes métriques du projet, nous voulons nous assurer que notre prototype ait un sens et contribue utilement à la problématique des \glspl{resinfo}.
+Dans ce chapitre-ci, nous nous efforçons d'avoir un regard critique sur \texttt{Source Code}. Par la validation du projet (test avec des utilisateurs externes, test de la qualité du code) et les différentes métriques du projet, nous voulons nous assurer que notre prototype ait un sens et contribue utilement à la problématique des \glspl{resinfo}.
 
 \import{sections/chapters/analyseCritique/}{validationExterne}
 

--- a/sections/chapters/analyseCritique/validationExterne.tex
+++ b/sections/chapters/analyseCritique/validationExterne.tex
@@ -3,13 +3,13 @@
 
 Pour valider notre travail, nous avions initialement planifié deux séances de validation afin de récolter les avis d'un panel d'utilisateurs suffisamment large et diversifié.
 Pour cause de COVID-19, nous n'avons pu organiser qu'une seule séance via Teams avec les utilisateurs disponibles : la partie professorale du panel ne disposant généralement plus d'assez de disponibilités à nous accorder. 
-Chaque personne se voyait attribuer deux rôles différents (visiteur-utilisateur ou visiteur-administrateur) afin de prendre connaissance des fonctionnalités les plus importantes de \texttt{SourceCode}. Notre évaluation a pu être réalisée grâce à Google Forms (réponses, graphiques) et vous retrouverez l'intégralité de ce sondage dans l'annexe \ref{annexe:googleForm}.\\
+Chaque personne se voyait attribuer deux rôles différents (visiteur-utilisateur ou visiteur-administrateur) afin de prendre connaissance des fonctionnalités les plus importantes de \texttt{Source Code}. Notre évaluation a pu être réalisée grâce à Google Forms (réponses, graphiques) et vous retrouverez l'intégralité de ce sondage dans l'annexe \ref{annexe:googleForm}.\\
 
 Parmi les participants, six d'entre eux font partie de la faculté \textit{EPL} de l'\textit{UCLouvain}, dont quatre étudiants de master en sciences informatiques et deux doctorants. La septième personne est une professeure en section informatique à la \textit{HELHa} de Mons.\\
 
-Un des premiers objectifs de cette séance fut de faire comprendre le but de la plateforme, son utilité. Cela semblait être acquis par la majorité sauf pour une personne. Il n'est pas exclu de penser que cette dernière était biaisée par la plateforme \textit{INGInious} de l'\textit{UCLouvain}, car elle l'a prise comme point de référence pour juger \texttt{SourceCode}.\\
+Un des premiers objectifs de cette séance fut de faire comprendre le but de la plateforme, son utilité. Cela semblait être acquis par la majorité sauf pour une personne. Il n'est pas exclu de penser que cette dernière était biaisée par la plateforme \textit{INGInious} de l'\textit{UCLouvain}, car elle l'a prise comme point de référence pour juger \texttt{Source Code}.\\
 
-Les sous-sections suivantes résument les critiques émises sur \texttt{SourceCode}. Certaines remarques suggéraient des améliorations et corrections. Avec le temps qui nous restait, nous avons essayé de les prendre en compte pour rendre l'utilisation de la plateforme un peu plus immersive et plus fonctionnelle. Vous retrouverez alors un "\textbf{(corrigé)}" quand nous avons pu prendre en considération la remarque.
+Les sous-sections suivantes résument les critiques émises sur \texttt{Source Code}. Certaines remarques suggéraient des améliorations et corrections. Avec le temps qui nous restait, nous avons essayé de les prendre en compte pour rendre l'utilisation de la plateforme un peu plus immersive et plus fonctionnelle. Vous retrouverez alors un "\textbf{(corrigé)}" quand nous avons pu prendre en considération la remarque.
 
 \subsection*{Bibliothèque}
 
@@ -56,7 +56,7 @@ Nos observations :
 
 \begin{enumerate}
     \item Actuellement, il faut d'abord créer un bloc de code puis copier-coller le code que l'on veut formater dedans. La \gls{library} d'édition de texte que nous utilisons (Tiptap) ne gère pas nativement ce qui a été soulevé dans la remarque. En revanche, cette même \gls{library} est extensible et autorise la modification/l'ajout de fonctionnalités de manière aisée. Il est donc tout à fait envisageable de corriger le tir dans une prochaine mise à jour de l'application.
-    \item Certaines personnes se plaignaient que la boîte d'édition était trop petite (ou trop grande). Dans son état actuel, \texttt{SourceCode} n'est pas responsive, et dans la perspective où elle le serait, ce problème sera certainement réglé pour tout écran.
+    \item Certaines personnes se plaignaient que la boîte d'édition était trop petite (ou trop grande). Dans son état actuel, \texttt{Source Code} n'est pas responsive, et dans la perspective où elle le serait, ce problème sera certainement réglé pour tout écran.
     \item Comme cela a déjà été soulevé dans la section concernant la bibliothèque, le panneau des \glspl{tag} est un peu lourd à l'utilisation. Il y avait jusqu'à 3 scrollbars pour naviguer dans le panneau, ce qui diminuait considérablement l'accessibilité. Nous avons donc corrigé ce comportement en faisant en sorte d'afficher une seule scrollbar, avec un accès plus clair à la barre de recherche sous chaque \glspl{tagCat}.
 \end{enumerate}
 
@@ -104,9 +104,9 @@ Nos observations :
 Nos observations :
 
 \begin{enumerate}
-    \item \texttt{SourceCode} pourra très rapidement posséder une riche bibliothèque de \glspl{resinfo} rien qu'avec les exercices stockés sur la plateforme \textit{INGInious}. Avec la promotion de la plateforme auprès d'autres institutions scolaires, \texttt{SourceCode} pourrait alors prétendre à une popularité certaine dans le monde des ressources partagées. Il s'agit alors de savoir vendre son produit avec les bons arguments...
+    \item \texttt{Source Code} pourra très rapidement posséder une riche bibliothèque de \glspl{resinfo} rien qu'avec les exercices stockés sur la plateforme \textit{INGInious}. Avec la promotion de la plateforme auprès d'autres institutions scolaires, \texttt{Source Code} pourrait alors prétendre à une popularité certaine dans le monde des ressources partagées. Il s'agit alors de savoir vendre son produit avec les bons arguments...
     \item Nous n'avions pas pensé à cela pour le prototype. Nous voulions d'abord créer un système cohérent et fonctionnel au niveau de la gestion des \glspl{resinfo} et \glspl{tag}. Les différents statuts attribuables à ces mêmes \glspl{resinfo} et \glspl{tag} jouent déjà un rôle majeur dans la gestion (ex. trier les \glspl{resinfo} non valides ou en attente de validation ...). En termes d'améliorations, nous pourrions automatiser le processus de validation afin que les administrateurs ne soient pas débordés (cf. chapitre \ref{chapter:pourAllerPlusLoin}).
-    \item C'est un point intéressant pour nous. \texttt{SourceCode} est une application qui tente de faciliter le plus possible la recherche et la gestion de \glspl{resinfo} (système de filtres, historique, favoris ...). Malheureusement, ajouter une pléthore de fonctionnalités peut aussi devenir une barrière à l'utilisation, car l'utilisateur doit d'abord apprendre à les maîtriser. Une des premières solutions que nous avons mises en place était la création d'une section tutoriel sur la plateforme, mais cela n'est qu'une solution de contournement. Une autre idée serait de prévoir une interface en fonction du public ciblé (débutant, "tech savvy" ...).
+    \item C'est un point intéressant pour nous. \texttt{Source Code} est une application qui tente de faciliter le plus possible la recherche et la gestion de \glspl{resinfo} (système de filtres, historique, favoris ...). Malheureusement, ajouter une pléthore de fonctionnalités peut aussi devenir une barrière à l'utilisation, car l'utilisateur doit d'abord apprendre à les maîtriser. Une des premières solutions que nous avons mises en place était la création d'une section tutoriel sur la plateforme, mais cela n'est qu'une solution de contournement. Une autre idée serait de prévoir une interface en fonction du public ciblé (débutant, "tech savvy" ...).
 \end{enumerate}
 
 \subsection*{Que pouvons-nous faire pour améliorer l'application ?}
@@ -138,7 +138,7 @@ Nos observations :
 Nos observations :
 
 \begin{enumerate}
-    \item \texttt{SourceCode} n'est pas prévu pour résoudre des exercices depuis la plateforme. À ce stade-ci, on peut la considérer comme un référenceur de \glspl{resinfo} qui faciliterait la recherche de ressources particulière avec un système de recherche complet. Dans une perspective future, \texttt{SourceCode} pourrait avoir son propre correcteur d'exercices si la ressource nécessite une résolution. Dans ce cas, cela profiterait aux étudiants pour s'évaluer.
+    \item \texttt{Source Code} n'est pas prévu pour résoudre des exercices depuis la plateforme. À ce stade-ci, on peut la considérer comme un référenceur de \glspl{resinfo} qui faciliterait la recherche de ressources particulière avec un système de recherche complet. Dans une perspective future, \texttt{Source Code} pourrait avoir son propre correcteur d'exercices si la ressource nécessite une résolution. Dans ce cas, cela profiterait aux étudiants pour s'évaluer.
     \item Certaines plateformes comme Hackerrank ou Coderbyte ont prévu une section forum pour chaque exercice/challenge. C'est une fonctionnalité intéressante, mais elle va de pair avec le point précédent.
 \end{enumerate}
 
@@ -169,4 +169,4 @@ Nos observations :
 
 Cette séance de validation a globalement été positive et instructive. Le message d'une plateforme de partage de \glspl{resinfo} à destination d'une équipe pédagogique semble être acquis par la majorité. 
 Nous avons appris que la plateforme dispose d'un design et d'une ergonomie satisfaisants. Il faut néanmoins y apporter quelques mises à jour pour rendre le projet mature, notamment au niveau de l'ergonomie.
-Certaines des fonctionnalités mentionnées dans les critiques ont pu être intégrées à \texttt{SourceCode} pour l'améliorer le plus possible. Pour celles qui n'ont pas été ajoutées, nous les avons référencées dans le chapitre \ref{chapter:pourAllerPlusLoin}.
+Certaines des fonctionnalités mentionnées dans les critiques ont pu être intégrées à \texttt{Source Code} pour l'améliorer le plus possible. Pour celles qui n'ont pas été ajoutées, nous les avons référencées dans le chapitre \ref{chapter:pourAllerPlusLoin}.

--- a/sections/chapters/analyseCritique/validationInterne.tex
+++ b/sections/chapters/analyseCritique/validationInterne.tex
@@ -44,7 +44,7 @@ Pour ce faire, nous avons repris des statistiques des répertoires GitHub du \gl
 
 \subsection{Graphe d'activité}
 
-\texttt{SourceCode} a connu un développement plus ou moins constant durant l'année académique 2019-2020. Étant donné que le \gls{frontend} et le \gls{backend} sont intimement liés, vous pourrez constater sur le graphe \ref{figure:frontendActivity} et \ref{figure:backendActivity} que la forte activité de l'un compense l'activité au ralenti de l'autre répertoire.
+\texttt{Source Code} a connu un développement plus ou moins constant durant l'année académique 2019-2020. Étant donné que le \gls{frontend} et le \gls{backend} sont intimement liés, vous pourrez constater sur le graphe \ref{figure:frontendActivity} et \ref{figure:backendActivity} que la forte activité de l'un compense l'activité au ralenti de l'autre répertoire.
 
 \begin{figure}[H]
     \includegraphics[width=\textwidth,height=0.3\textheight,keepaspectratio]{images/analyseCritique/graph_frontend.png}
@@ -63,4 +63,4 @@ Les fonctionnalités les plus importantes comme la recherche dans la bibliothèq
 \end{figure}
 
 
-Globalement, nous avons respecté le planning \ref{pic:ganttChart} que nous nous sommes imposé. Nous avons cependant effectué une dernière mise à jour prenant en compte un maximum des remarques relatées en section \ref{section:validationExterne}, car nous voulions prouver que \texttt{SourceCode} est capable de s'adapter aux besoins des utilisateurs.
+Globalement, nous avons respecté le planning \ref{pic:ganttChart} que nous nous sommes imposé. Nous avons cependant effectué une dernière mise à jour prenant en compte un maximum des remarques relatées en section \ref{section:validationExterne}, car nous voulions prouver que \texttt{Source Code} est capable de s'adapter aux besoins des utilisateurs.

--- a/sections/chapters/cahierDesCharges/index.tex
+++ b/sections/chapters/cahierDesCharges/index.tex
@@ -12,7 +12,7 @@ La principale fonctionnalité attendue de l'application web est la recherche de 
 
 \subsection*{Les différents types d'utilisateurs}
 
-\paragraph{} \texttt{SourceCode} repose sur la participation active d'acteurs variés. Cela nécessite la mise en place d'une organisation sous forme de rôles afin de maintenir cette plateforme de ressources \textit{cohérente} et \textit{qualitative}. Notre analyse nous a permis d'isoler \textbf{4 types d'utilisateurs} disposant de \textit{privilèges additionnels} (en plus de leurs privilèges propres, chacun hérite aussi de ceux du précédent de la présente liste) :
+\paragraph{} \texttt{Source Code} repose sur la participation active d'acteurs variés. Cela nécessite la mise en place d'une organisation sous forme de rôles afin de maintenir cette plateforme de ressources \textit{cohérente} et \textit{qualitative}. Notre analyse nous a permis d'isoler \textbf{4 types d'utilisateurs} disposant de \textit{privilèges additionnels} (en plus de leurs privilèges propres, chacun hérite aussi de ceux du précédent de la présente liste) :
 
 \begin{itemize}
     \item \textbf{Visiteur} : Il s'agit d'un utilisateur non inscrit à notre plateforme. Il ne peut rechercher et consulter que les \glspl{fiche} de ressources validées par un administrateur.
@@ -164,7 +164,7 @@ Dès lors, il est plus aisé d'identifier quelle(s) \gls{fiche}(s) corresponde(n
     \label{tab:fichesWithTagTh}
 \end{table}
 
-Nous reviendrons d'ailleurs ultérieurement (cf. section \ref{section:SearchTagImpl}, figure \ref{figure:bibliothequeOverview}...) sur les façons dont nous avons mis en place cette réflexion dans l'implémentation de \texttt{SourceCode}.
+Nous reviendrons d'ailleurs ultérieurement (cf. section \ref{section:SearchTagImpl}, figure \ref{figure:bibliothequeOverview}...) sur les façons dont nous avons mis en place cette réflexion dans l'implémentation de \texttt{Source Code}.
 Vous pourrez noter, qu'en dépit de conventions d'écriture différentes (car inhérentes au contexte), les tables \ref{tab:fichesWithTagTh} et \ref{tab:fichesWithTagImpl} expriment les mêmes principes.
 
 \pagebreak
@@ -249,7 +249,7 @@ Au fur et à mesure de nos meetings avec le professeur \textit{Kim Mens} et \tex
 \section {Contraintes}
 \label{sec:ContraintesCdc}
 
-Une première contrainte évidente est indubitablement le temps. Nous avons consacré une année académique entière sur ce mémoire, mais ce n'est certainement pas assez pour rendre mature \texttt{SourceCode}.\\
+Une première contrainte évidente est indubitablement le temps. Nous avons consacré une année académique entière sur ce mémoire, mais ce n'est certainement pas assez pour rendre mature \texttt{Source Code}.\\
 
 Pour la partie \gls{frontend}, nous avons décidé de nous consacrer uniquement sur le design et l'ergonomie d'un desktop ayant une largeur minimale de 1550 pixels. Pour l'instant, nous avons recommandé aux utilisateurs de l'application ayant une petite résolution de modifier l'échelle du navigateur internet afin d'avoir une expérience optimale malgré notre contrainte. Créer les autres déclinaisons pour petits desktop, tablettes et smartphones ne nous auraient pas permis d'intégrer toutes les fonctionnalités qu'on avait prévu d'ajouter sur la plateforme, car cela aurait pris trop de temps (modifier la disposition des éléments, créer de nouveaux éléments, changer le layout ...). \\
 

--- a/sections/chapters/introduction/index.tex
+++ b/sections/chapters/introduction/index.tex
@@ -30,9 +30,9 @@ Avant de démarrer la réalisation de la plateforme web, nous devions impérativ
 
 Le premier temps consistait à analyser des plateformes similaires existantes afin d'en extraire des éléments visuels ou fonctionnels pertinents pour ce projet tandis que pour le second, il nous fallait effectuer d'une part, une analyse fonctionnelle regroupant l'organisation de la plateforme et les fonctionnalités à intégrer avec la méthode \textit{\textbf{MoSCoW}}, et d'autre part une analyse non fonctionnelle afin d'y relater les diverses contraintes du projet, les critères de sécurité et de maintenance.\\
 
-Après cette phase d'analyse, nous nous sommes attelés à l'architecture de \texttt{SourceCode} à l'aide d'un patchwork présentant les fonctionnalités essentielles de l'application côté \gls{frontend} et de schémas UML pour la base de données.\\
+Après cette phase d'analyse, nous nous sommes attelés à l'architecture de \texttt{Source Code} à l'aide d'un patchwork présentant les fonctionnalités essentielles de l'application côté \gls{frontend} et de schémas UML pour la base de données.\\
 
-Nous avons ensuite pu travailler sur l'implémentation de \texttt{SourceCode} pour intégrer les fonctionnalités listées dans l'analyse fonctionnelle. Cette phase s'est déroulée durant quasiment toute l'année académique, sous l'œil avisé de nos promoteurs pour garantir une cohérence dans notre travail.\\
+Nous avons ensuite pu travailler sur l'implémentation de \texttt{Source Code} pour intégrer les fonctionnalités listées dans l'analyse fonctionnelle. Cette phase s'est déroulée durant quasiment toute l'année académique, sous l'œil avisé de nos promoteurs pour garantir une cohérence dans notre travail.\\
 
 L'étape finale fut la validation du projet, où nous avions convié des utilisateurs pour tester l'application dans son entièreté. Nous voulions nous assurer que notre mémoire fasse sens et soit utile pour la problématique que nous visons. Suite aux diverses remarques, nous avons pu effectuer une dernière itération de développement afin de prendre en considération les commentaires reçus.
 
@@ -45,6 +45,6 @@ Au travers de ce mémoire, nous espérons avoir contribué à la problématique 
 Nous allons d'abord définir les besoins clés d'une application de partage de \glspl{resinfo} en analysant une série de plateformes web existantes (cf. chapitre \ref{chapter:problematique}).
 Après cela, nous allons nous concentrer sur une analyse plus poussée de notre plateforme en y relatant les fonctionnalités à intégrer, les besoins à satisfaire pour que la plateforme puisse être utilisée par le grand public, ainsi que les contraintes qui ont été imposées (cf. chapitre \ref{chapter:analyseDesBesoins}).\\
 
-Nous allons par la suite expliquer notre solution à la problématique du partage de \glspl{resinfo} en détaillant l'architecture de \texttt{SourceCode} aussi bien du côté \gls{frontend} que du \gls{backend} (cf. chapitre \ref{chapter:solution}).
+Nous allons par la suite expliquer notre solution à la problématique du partage de \glspl{resinfo} en détaillant l'architecture de \texttt{Source Code} aussi bien du côté \gls{frontend} que du \gls{backend} (cf. chapitre \ref{chapter:solution}).
 Pour poursuivre, nous prendrons du recul sur le projet en évoquant la phase de validation et les métriques (cf. chapitre \ref{section:validation}). 
 Enfin, nous discuterons du futur de la plateforme à travers un roadmap de fonctionnalités à intégrer pour une future itération de la plateforme (cf. chapitre \ref{chapter:pourAllerPlusLoin}).

--- a/sections/chapters/pourAllerPlusLoin/index.tex
+++ b/sections/chapters/pourAllerPlusLoin/index.tex
@@ -1,11 +1,11 @@
 \chapter{Pour aller plus loin}
 \label{chapter:pourAllerPlusLoin}
 
-Ce chapitre tente de rassembler tous les futurs travaux qui pourront être apportés à \texttt{SourceCode}.\\
+Ce chapitre tente de rassembler tous les futurs travaux qui pourront être apportés à \texttt{Source Code}.\\
 
 Durant notre année académique, nos promoteurs ont gardé un œil sur le projet afin de nous proposer quelques pistes pour améliorer l'application.
 Parallèlement, nous avons pu rencontrer \textit{Christine Jacqmot}, membre du Louvain Learning Lab, qui nous a partagé son expérience des \gls{oer} avec quelques conseils pour notre plateforme. 
-Grâce à ces précieux avis, à notre prise de recul et aux remarques récoltées lors de la séance de validation (cf. \ref{section:validation}) avec des utilisateurs, nous avons dressé une liste des améliorations possibles pour \texttt{SourceCode}.
+Grâce à ces précieux avis, à notre prise de recul et aux remarques récoltées lors de la séance de validation (cf. \ref{section:validation}) avec des utilisateurs, nous avons dressé une liste des améliorations possibles pour \texttt{Source Code}.
 
 \section{Liste des améliorations}
 
@@ -22,7 +22,7 @@ Grâce à ces précieux avis, à notre prise de recul et aux remarques récolté
     \item Ajouter le multi-upload de fichier dans le formulaire de création/modification d'une \gls{resinfo}.
     \item Ajouter le preview de fichier quand c'est possible (image, pdf, word,...) dans le formulaire de création/modification de \glspl{resinfo}.
     \item Avoir la possibilité de rendre certains favoris publics afin de les partager avec les autres et les sauvegarder dans ses propres favoris.
-    \item Ajouter la compatibilité avec les normes Dublin Core et LOM (cf. annexe \ref{annexe:AnalyseBiblio}, pratique pour l'export sous un certain format et l'import capable de convertir les formats). Cela permettra à \texttt{SourceCode} de s'ouvrir à d'autres plateformes qui utilisent d'autres normes.
+    \item Ajouter la compatibilité avec les normes Dublin Core et LOM (cf. annexe \ref{annexe:AnalyseBiblio}, pratique pour l'export sous un certain format et l'import capable de convertir les formats). Cela permettra à \texttt{Source Code} de s'ouvrir à d'autres plateformes qui utilisent d'autres normes.
     \item Gestion de la recherche approximative dans la bibliothèque avec propositions de recherche.
     \item Améliorer la lisibilité des \glspl{tag} dans le formulaire de création de \glspl{resinfo} ou de favoris. Il faut pouvoir distinguer à quelle \gls{tagCat} un \gls{tag} appartient, sans devoir rechercher dans le panneau de filtres.
     \item Améliorer l'éditeur de texte pour la création/modification d'une \gls{resinfo}.

--- a/sections/chapters/problematique/index.tex
+++ b/sections/chapters/problematique/index.tex
@@ -1,12 +1,12 @@
 \chapter{Problématique}
 \label{chapter:problematique}
 
-Dans ce chapitre, nous allons nous concentrer sur l'analyse d'applications web existantes. Cette dernière est importante, car elle nous permettra de définir les besoins clés d'une application de partage de \glspl{resinfo}. Cette étape correspond à la première phase de notre planning (cf. figure \ref{pic:ganttChart} en rouge). Vous pouvez considérer ce chapitre comme une introduction au chapitre \ref{chapter:analyseDesBesoins}, où nous développerons plus en détail les besoins spécifiques de \texttt{SourceCode}.
+Dans ce chapitre, nous allons nous concentrer sur l'analyse d'applications web existantes. Cette dernière est importante, car elle nous permettra de définir les besoins clés d'une application de partage de \glspl{resinfo}. Cette étape correspond à la première phase de notre planning (cf. figure \ref{pic:ganttChart} en rouge). Vous pouvez considérer ce chapitre comme une introduction au chapitre \ref{chapter:analyseDesBesoins}, où nous développerons plus en détail les besoins spécifiques de \texttt{Source Code}.
 
 \section{Situation actuelle}
 \label{section:situation}
 
-Pour mieux comprendre l'univers des \glspl{resinfo}, nous avons analysé différentes plateformes. Bien que ces dernières n'apportent pas de solution précisément axée sur notre problématique, elles nous ont tout de même permis d'extraire des éléments pertinents à la création de notre plateforme : \texttt{SourceCode}.\\
+Pour mieux comprendre l'univers des \glspl{resinfo}, nous avons analysé différentes plateformes. Bien que ces dernières n'apportent pas de solution précisément axée sur notre problématique, elles nous ont tout de même permis d'extraire des éléments pertinents à la création de notre plateforme : \texttt{Source Code}.\\
 
 Le tableau ci-dessous regroupe les différents sites web parcourus. Dans les sous-sections suivantes, nous listons les qualités et les défauts de chacune de ces plateformes. Vous retrouverez les captures d'écran représentant les différentes plateformes dans l'annexe \ref{annexe:problematique}.\\
 
@@ -39,7 +39,7 @@ Le tableau ci-dessous regroupe les différents sites web parcourus. Dans les sou
     \label{table:compPlateforme}
 \end{table}
 
-Avant d'aller plus loin, nous tenons à mentionner l'outil \href{https://oer.uclouvain.be/}{OER UCLouvain} hors du champ de notre analyse. En effet, notre projet est une version simplifiée de leur application, car nous ne traitons qu'un seul domaine des \gls{oer} : les \glspl{resinfo}. Par conséquent, le système de recherche que le site propose ne correspond pas à la vision que nous avons pour notre type de plateforme étant donné qu'il est beaucoup plus complexe que ce que nous voulons mettre en place : Un catalogue de \glspl{resinfo}. Néanmoins, nous avons pu discuter avec \textit{Christine Jacqmot}, membre du \textit{Louvain Learning Lab}, afin de lui présenter notre projet et de voir comment se comporte l'outil \href{https://oer.uclouvain.be/}{OER UCLouvain} côté administration. Ses conseils nous ont aidés à améliorer notre prototype et dans le cas échéant, à rajouter dans le chapitre \ref{chapter:pourAllerPlusLoin} des précieuses pistes d'améliorations.
+Avant d'aller plus loin, nous tenons à mentionner l'outil \href{https://oer.uclouvain.be/}{OER UCLouvain} hors du champ de notre analyse. En effet, notre projet est une version simplifiée de leur application, car nous ne traitons qu'un seul domaine des \gls{oer} : les \glspl{resinfo}. Par conséquent, le système de recherche que le site propose ne correspond pas à la vision que nous avons pour notre type de plateforme étant donné qu'il est beaucoup plus complexe que ce que nous voulons mettre en place : un catalogue de \glspl{resinfo}. Néanmoins, nous avons pu discuter avec \textit{Christine Jacqmot}, membre du \textit{Louvain Learning Lab}, afin de lui présenter notre projet et de voir comment se comporte l'outil \href{https://oer.uclouvain.be/}{OER UCLouvain} côté administration. Ses conseils nous ont aidés à améliorer notre prototype et dans le cas échéant, à rajouter dans le chapitre \ref{chapter:pourAllerPlusLoin} des précieuses pistes d'améliorations.
 \pagebreak
 \subsection*{Practice-it}
 
@@ -210,9 +210,9 @@ Cette plateforme est un exemple concret de site web que nous ne voulons pas cré
 
 \subsection*{Conclusion sur l'analyse}
 
-Cette analyse nous a permis de partir sur de bonnes bases pour la création de notre application web. Nous voulions nous inspirer de certaines interfaces proposant de bonnes idées au niveau de la recherche pure, car cette dernière sera l'une des fonctionnalités principales de \texttt{SourceCode}. \\
+Cette analyse nous a permis de partir sur de bonnes bases pour la création de notre application web. Nous voulions nous inspirer de certaines interfaces proposant de bonnes idées au niveau de la recherche pure, car cette dernière sera l'une des fonctionnalités principales de \texttt{Source Code}. \\
 
-Certaines fonctionnalités comme l'espace de discussion sur un challenge spécifique ou encore la soumission de sa solution directement sur la plateforme demeurent de bonnes idées, mais pas nécessaires à l'élaboration d'une application comme \texttt{SourceCode}, car l'objectif premier est le référencement de \glspl{resinfo} avant tout. Dans une perspective future, l'intégration de ce genre de fonctionnalités pourrait bien sûr être envisageable, ce qui rendrait ce projet encore plus flexible.\\
+Certaines fonctionnalités comme l'espace de discussion sur un challenge spécifique ou encore la soumission de sa solution directement sur la plateforme demeurent de bonnes idées, mais pas nécessaires à l'élaboration d'une application comme \texttt{Source Code}, car l'objectif premier est le référencement de \glspl{resinfo} avant tout. Dans une perspective future, l'intégration de ce genre de fonctionnalités pourrait bien sûr être envisageable, ce qui rendrait ce projet encore plus flexible.\\
 
 Avec le support de cette analyse, nous avons pu constituer une liste des éléments importants devant être intégrés au projet. Cela a aussi servi à mettre sur papier nos idées à travers un patchwork que vous pourrez consulter dans la section \ref{section:problem}.
 
@@ -222,7 +222,7 @@ Avec le support de cette analyse, nous avons pu constituer une liste des éléme
 
 Compte tenu de l'analyse des plateformes précédentes, nous allons nous intéresser aux obstacles à franchir pour créer une plateforme de partage de \glspl{resinfo}, en particulier la nôtre.\\
 
-La recherche de \glspl{resinfo} demeure la base de \texttt{SourceCode}. Par conséquent, l'élaboration d'une \textbf{bibliothèque} proposant une recherche efficace et pratique est un premier jalon à traverser. Il faut que l'utilisateur comprenne assez rapidement comment interagir avec l'interface pour trouver des \glspl{resinfo} correspondant à ses critères de recherche (exemples : exercices avec le langage C, thématique sur les pointeurs, ...).\\
+La recherche de \glspl{resinfo} demeure la base de \texttt{Source Code}. Par conséquent, l'élaboration d'une \textbf{bibliothèque} proposant une recherche efficace et pratique est un premier jalon à traverser. Il faut que l'utilisateur comprenne assez rapidement comment interagir avec l'interface pour trouver des \glspl{resinfo} correspondant à ses critères de recherche (exemples : exercices avec le langage C, thématique sur les pointeurs, ...).\\
 
 Se pose ensuite la question du \textbf{contenu d'une \gls{fiche}}. Cette dernière contiendrait probablement un titre et une description (énoncé d'un exercice, tutoriel), mais le plus important reste son \textbf{référencement} à travers l'application. Il s'agirait alors d'intégrer un système de \glspl{tag} cohérent permettant de retrouver rapidement une \gls{fiche} dans la bibliothèque.\\
 
@@ -236,7 +236,7 @@ Pour poursuivre avec le critère de \textit{qualité} du contenu, il serait judi
 
 Toujours dans l'optique d'améliorer la qualité du contenu de la plateforme, un \textbf{système de vote} devrait être mis en place afin de laisser la communauté s'exprimer sur la pertinence d'une \gls{resinfo}. La modération est une première instance de validation des \glspl{resinfo} ajoutées sur la plateforme, mais nous estimons que la communauté doit aussi pouvoir donner son avis. Cela permettrait d'une part au créateur de la \gls{resinfo} d'améliorer sa \gls{fiche} et d'autre part aux administrateurs d'émettre une nouvelle évaluation de la \gls{resinfo}.\\
 
-Afin de vous donner une petite idée de ce que nous avons imaginé après la première analyse des plateformes, nous vous proposons quelques illustrations de notre patchwork pour la partie bibliothèque et la consultation d'une \gls{fiche}. \textbf{Ceci n'est pas un design final de \texttt{SourceCode}}, mais plutôt une mise sur papier de notre conception de l'application web au vu des critères exposés précédemment.\\
+Afin de vous donner une petite idée de ce que nous avons imaginé après la première analyse des plateformes, nous vous proposons quelques illustrations de notre patchwork pour la partie bibliothèque et la consultation d'une \gls{fiche}. \textbf{Ceci n'est pas un design final de \texttt{Source Code}}, mais plutôt une mise sur papier de notre conception de l'application web au vu des critères exposés précédemment.\\
 
 \begin{figure}[H]
     \includegraphics[width=\textwidth,height=\textheight,keepaspectratio]{images/library.JPG}
@@ -263,7 +263,7 @@ Afin de vous donner une petite idée de ce que nous avons imaginé après la pre
 \section{Défis à relever}
 \label{section:challengesToDefeat}
 
-Après avoir formalisé les besoins d'une application de partage de \glspl{resinfo}, nous allons maintenant lister ce que nous allons mettre en place pour réaliser notre plateforme. Notez que cette liste est introductive à l'analyse fonctionnelle relatée dans la section \ref{section:analyseFonctionnelle}, mais nous avions besoin de cette étape pour avoir une vue au global de \texttt{SourceCode} avant d'aller un peu plus dans les détails.
+Après avoir formalisé les besoins d'une application de partage de \glspl{resinfo}, nous allons maintenant lister ce que nous allons mettre en place pour réaliser notre plateforme. Notez que cette liste est introductive à l'analyse fonctionnelle relatée dans la section \ref{section:analyseFonctionnelle}, mais nous avions besoin de cette étape pour avoir une vue au global de \texttt{Source Code} avant d'aller un peu plus dans les détails.
 
 \begin{itemize}
     \item Proposer une interface simple et ergonomique à destination d'un public varié. Pour rappel, la cible principale est l'équipe pédagogique (professeurs, doctorants, formateurs, ...), le reste étant majoritairement des étudiants. Peu importe le type d'utilisateur, l'outil doit être suffisamment clair que pour comprendre les fonctionnalités clés de l'application (recherche de \glspl{resinfo}, création de \glspl{fiche}, gestion des favoris,...).
@@ -279,4 +279,4 @@ Pour conclure ce chapitre et cette section, il est important de noter que la cr�
 
 Chaque page doit être réfléchie en matière d'ergonomie et de design pour que l'utilisateur ait envie de continuer à naviguer sur la plateforme. Côté développement, l'ensemble du code doit être suffisamment modulaire afin d'apporter de nouvelles fonctionnalités de manière aisée (évolution de l'application). Au plus du temps sera investi dans un tel projet, au plus ce dernier sera mature et agréable à prendre en main pour chaque classe d'utilisateur, car nous aurons appris à comprendre leurs besoins. Nous pensons particulièrement à la recherche de \glspl{resinfo} et à la gestion de ces mêmes \glspl{resinfo}, \glspl{tag}, \glspl{tagCat}.\\
 
-\texttt{SourceCode} n'aura pas la prétention d'être en version finale, il se positionnera plus sur la dénomination de \textbf{prototype}. En effet, notre volonté principale est avant tout de contribuer au domaine des ressources partagées, car nous pensons que ce dernier est porteur d'une riche communauté d'entre-aide. C'est pourquoi le titre de notre mémoire contient les mots \textbf{\textit{open source}}, car nous prenons exemple sur ce mode d'organisation pour créer cet outil de partage.
+\texttt{Source Code} n'aura pas la prétention d'être en version finale, il se positionnera plus sur la dénomination de \textbf{prototype}. En effet, notre volonté principale est avant tout de contribuer au domaine des ressources partagées, car nous pensons que ce dernier est porteur d'une riche communauté d'entre-aide. C'est pourquoi le titre de notre mémoire contient les mots \textbf{\textit{open source}}, car nous prenons exemple sur ce mode d'organisation pour créer cet outil de partage.

--- a/sections/chapters/solution/api/index.tex
+++ b/sections/chapters/solution/api/index.tex
@@ -2,7 +2,7 @@
 \section{Serveur}
 \label{chapter:api}
 
-Cette section est entièrement dédiée à la conception du \gls{backend} de \texttt{SourceCode}.
+Cette section est entièrement dédiée à la conception du \gls{backend} de \texttt{Source Code}.
 Puisque cette partie est l'extrême opposé de la précédente (cf. section \ref{chapter:client}), nous l'aborderons par sa réalisation technique, en nous concentrant sur l'essentiel.
 
 \subsection{Structure du projet}
@@ -67,7 +67,7 @@ Pour répondre aux besoins exprimés en chapitre \ref{chapter:analyseDesBesoins}
         ]
       ]
    \end{forest}
-    \caption[SourceCode : Arborescence de l'API]{Arborescence de l'\Gls{api}}
+    \caption[Source Code : Arborescence de l'API]{Arborescence de l'\Gls{api}}
     \label{fig:arborenceAPI}
 \end{figure}
 

--- a/sections/chapters/solution/choixTechno/index.tex
+++ b/sections/chapters/solution/choixTechno/index.tex
@@ -252,7 +252,7 @@ Cette \gls{library} propose un grand nombre de fonctionnalités dont nous allons
 
 \noindent\underline{\href{https://logaretm.github.io/vee-validate/}{VeeValidate}}\\
 
-Un excellent framework, construit pour VueJS, responsable de la validation des différents formulaires présents sur \texttt{SourceCode}. Très facilement, nous pouvons importer des règles de validation (\textit{min} pour minimum de caractères, \textit{max} pour maximum de caractère, \textit{required} pour champs obligatoire ...) depuis VeeValidate et les ajouter au composant responsable de la validation du champ.\\
+Un excellent framework, construit pour VueJS, responsable de la validation des différents formulaires présents sur \texttt{Source Code}. Très facilement, nous pouvons importer des règles de validation (\textit{min} pour minimum de caractères, \textit{max} pour maximum de caractère, \textit{required} pour champs obligatoire ...) depuis VeeValidate et les ajouter au composant responsable de la validation du champ.\\
 
 Voici un petit exemple d'utilisation tiré du fichier \texttt{login.vue}, responsable d'afficher la page de connexion à un compte :\\
 

--- a/sections/chapters/solution/client/index.tex
+++ b/sections/chapters/solution/client/index.tex
@@ -1,11 +1,11 @@
 \section{Client}
 \label{chapter:client}
 
-Cette section est entièrement dédiée à la conception du \gls{frontend} de \texttt{SourceCode}. Étant donné qu'il s'agit de la partie visuelle et ergonomique du site, nous aborderons cette thématique de manière plus illustrative.\\
+Cette section est entièrement dédiée à la conception du \gls{frontend} de \texttt{Source Code}. Étant donné qu'il s'agit de la partie visuelle et ergonomique du site, nous aborderons cette thématique de manière plus illustrative.\\
 
 Pour ce faire, nous allons naviguer à travers les différentes pages de la plateforme en expliquant nos choix d'implémentation et les fonctionnalités qui ont été mises en place.\\
 
-Afin de vous donner une idée plus claire de ce qui va être abordé, voici une représentation du groupe d'URL de premier niveau que contient \texttt{SourceCode}.\\
+Afin de vous donner une idée plus claire de ce qui va être abordé, voici une représentation du groupe d'URL de premier niveau que contient \texttt{Source Code}.\\
 
 \begin{figure}[H]
     \centering
@@ -22,26 +22,26 @@ Afin de vous donner une idée plus claire de ce qui va être abordé, voici une 
          [tutoriel]
         ]
     \end{forest}
-    \caption[SourceCode : Représentation des URL de premier niveau]{URL de premier niveau}
+    \caption[Source Code : Représentation des URL de premier niveau]{URL de premier niveau}
 \end{figure}
 
 Cette figure sera notre fil conducteur tout au long de cette section, car nous allons analyser chaque partie en profondeur. 
 Les URL en \textbf{noir} signifient qu'elles renferment un niveau supplémentaire d'URL tandis que les \textbf{bleus} désignent une page de contenu.\\
 
-Les deux premières URL de la figure désignent les interfaces de connexion à \texttt{SourceCode} ainsi que la création d'un compte.\\
+Les deux premières URL de la figure désignent les interfaces de connexion à \texttt{Source Code} ainsi que la création d'un compte.\\
 
-L'URL \textit{/exercices} représente la bibliothèque de \glspl{resinfo}. C'est dans cet espace que le coeur de \texttt{SourceCode} réside, car c'est là que le système de recherche a été pensé pour tout le reste de la plateforme. En outre,
+L'URL \textit{/exercices} représente la bibliothèque de \glspl{resinfo}. C'est dans cet espace que le coeur de \texttt{Source Code} réside, car c'est là que le système de recherche a été pensé pour tout le reste de la plateforme. En outre,
 cette même URL contient aussi la consultation de \glspl{fiche} lorsque les critères de recherche de l'utilisateur sont satisfaits. À noter que tout type d'utilisateur peut accéder à ces pages.\\
 
 L'URL \textit{/gestion} renferme tout ce dont un utilisateur (connecté avec son compte) peut effectuer sur la plateforme pour enrichir son utilisation. On y répertorie la gestion/création/modification de ses propres \glspl{resinfo}, la gestion/création/modification de ses favoris pour faciliter la recherche et enfin, la consultation de son profil. Cette partie est accessible aux utilisateurs et (super-)administrateurs.\\
 
-L'URL \textit{/administration} contient les fonctionnalités exigeant le plus haut niveau de privilèges sur \texttt{SourceCode}. Cette partie est donc entièrement dédiée aux administrateurs et super-administrateurs. Ils peuvent gérer absolument toutes les \glspl{resinfo} disponibles sur la plateforme (impliquant aussi la modification et création de celles-ci), l'importation/exportation de \glspl{resinfo}, la gestion/création/modification de \glspl{tag}, la gestion/création/modification des \glspl{tagCat} et finalement la gestion des utilisateurs de la plateforme.\\
+L'URL \textit{/administration} contient les fonctionnalités exigeant le plus haut niveau de privilèges sur \texttt{Source Code}. Cette partie est donc entièrement dédiée aux administrateurs et super-administrateurs. Ils peuvent gérer absolument toutes les \glspl{resinfo} disponibles sur la plateforme (impliquant aussi la modification et création de celles-ci), l'importation/exportation de \glspl{resinfo}, la gestion/création/modification de \glspl{tag}, la gestion/création/modification des \glspl{tagCat} et finalement la gestion des utilisateurs de la plateforme.\\
 
 \pagebreak
 
-L'URL \textit{/tutoriel} concerne un aspect plus ludique de \texttt{SourceCode}. À travers différentes pages, une thématique de l'application est décortiquée afin que l'utilisateur puisse améliorer sa prise en main avec la plateforme.\\
+L'URL \textit{/tutoriel} concerne un aspect plus ludique de \texttt{Source Code}. À travers différentes pages, une thématique de l'application est décortiquée afin que l'utilisateur puisse améliorer sa prise en main avec la plateforme.\\
 
-Avant d'aller plus loin, considérez la section \ref{section:challengesToDefeat} afin de vous remettre en tête ce que nous voulions apporter à \texttt{SourceCode}.
+Avant d'aller plus loin, considérez la section \ref{section:challengesToDefeat} afin de vous remettre en tête ce que nous voulions apporter à \texttt{Source Code}.
 
 \subsection{Connexion et création de comptes}
 
@@ -61,7 +61,7 @@ Le formulaire de création nécessite une adresse email (unique), un mot de pass
 \begin{figure}[H]
     \includegraphics[width=\textwidth,height=0.35\textheight,keepaspectratio]{images/client/login.png}
     \centering
-    \caption[SourceCode : interface de connexion]{Interface de connexion}
+    \caption[Source Code : interface de connexion]{Interface de connexion}
 \end{figure}
 
 Lorsque l'utilisateur possède déjà un compte, il lui suffit de renseigner son adresse email et son mot de passe. Pour l'instant, une session d'une heure lui sera attribuée pour gérer ses ressources, favoris, ... Après quoi il sera redirigé vers la page de login pour entrer à nouveau ses identifiants. Ce comportement est bien évidemment modifiable depuis l'api (cf. section \ref{section:apiConfig}), mais nous avions surtout choisi ce timing pour la séance de validation de notre plateforme (cf. \ref{annexe:googleForm}).\\
@@ -71,7 +71,7 @@ Lorsque l'utilisateur possède déjà un compte, il lui suffit de renseigner son
 
 \subsection{Exercices}
 
-La bibliothèque constitue l'élément central de \texttt{SourceCode} pour le partage de ressources. C'est dans cet espace que les \glspl{resinfo} validées par la communauté apparaitront.\\
+La bibliothèque constitue l'élément central de \texttt{Source Code} pour le partage de ressources. C'est dans cet espace que les \glspl{resinfo} validées par la communauté apparaitront.\\
 
 \begin{figure}[H]
     \centering
@@ -84,7 +84,7 @@ La bibliothèque constitue l'élément central de \texttt{SourceCode} pour le pa
          [\textunderscore id/,highlight]
         ]
     \end{forest}
-    \caption[SourceCode : partie bibliothèque]{Partie bibliothèque (URL)}
+    \caption[Source Code : partie bibliothèque]{Partie bibliothèque (URL)}
 \end{figure}
 
 Cette section peut se découper en deux parties distinctes :
@@ -105,7 +105,7 @@ Concernant l'interface, nous nous sommes inspirés de \textit{Coderbyte} et \tex
 \begin{figure}[H]
     \includegraphics[width=\textwidth,height=\textheight,keepaspectratio]{images/client/search-library.png}
     \centering
-    \caption[SourceCode : page bibliothèque]{page bibliothèque}
+    \caption[Source Code : page bibliothèque]{page bibliothèque}
     \label{figure:bibliothequeOverview}
 \end{figure}
 
@@ -170,14 +170,14 @@ Vous pouvez supprimer ou modifier les favoris depuis ce panneau en passant la so
 \subsubsection{La \gls{fiche} d’une \gls{resinfo}}
 \label{section:ficheResInfo}
 
-Les \glspl{resinfo} sont le cœur de \texttt{SourceCode}. Elles représentent toutes les contributions émises par la communauté. Elles peuvent être consultées depuis la bibliothèque en cliquant sur "voir l'exercice".\\
+Les \glspl{resinfo} sont le cœur de \texttt{Source Code}. Elles représentent toutes les contributions émises par la communauté. Elles peuvent être consultées depuis la bibliothèque en cliquant sur "voir l'exercice".\\
 
 Voici à quoi ressemble la structure d'une \gls{fiche} :
 
 \begin{figure}[H]
     \includegraphics[width=\textwidth,height=\textheight,keepaspectratio]{images/client/fiche.png}
     \centering
-    \caption[SourceCode : la représentation d'une \gls{fiche}]{la représentation d'une \gls{fiche}}
+    \caption[Source Code : la représentation d'une \gls{fiche}]{la représentation d'une \gls{fiche}}
 \end{figure}
 
 Lorsque la ressource vous appartient ou que vous êtes un administrateur, un bouton de modification apparait dans le coin supérieur droit de la \gls{fiche} de la ressource. Cliquer sur le bouton mènera sur le formulaire de modification de la ressource (cf. section \ref{section:gestionResInfo} pour la gestion côté utilisateur ou section \ref{section:resInfoAdmin} pour la gestion côté (super-)administrateur).\\
@@ -231,7 +231,7 @@ Ce module est accessible aux utilisateurs (possédant un compte) et aux administ
          [profil,highlight]
         ]
     \end{forest}
-    \caption[SourceCode : module de gestion (URL)]{Module de gestion (URL)}
+    \caption[Source Code : module de gestion (URL)]{Module de gestion (URL)}
 \end{figure}
 
 \subsubsection{Gestion de \glspl{resinfo} personnelles}
@@ -242,7 +242,7 @@ La recherche fonctionne de la même manière que dans la bibliothèque, à la di
 \begin{figure}[H]
     \includegraphics[width=\textwidth,height=\textheight,keepaspectratio]{images/client/gestion-exercices.png}
     \centering
-    \caption[SourceCode : gestion des \glspl{resinfo} personnelles]{Gestion des \glspl{resinfo} personnelles (mes-exercices/)}
+    \caption[Source Code : gestion des \glspl{resinfo} personnelles]{Gestion des \glspl{resinfo} personnelles (mes-exercices/)}
 \end{figure}
 
 Plusieurs informations sont disponibles pour identifier les ressources informatiques :
@@ -303,7 +303,7 @@ Plus d'options seront disponibles pour les administrateurs, car il est évident 
 
 \begin{figure}[H]
     \includegraphics[width=\textwidth,height=\textheight,keepaspectratio]{images/client/gestion-options.png}
-    \caption[SourceCode : créer une \gls{resinfo}]{Gestion des \glspl{resinfo} personnelles (creer-exercice ou \_id)}
+    \caption[Source Code : créer une \gls{resinfo}]{Gestion des \glspl{resinfo} personnelles (creer-exercice ou \_id)}
     \centering
 \end{figure}
 
@@ -361,7 +361,7 @@ Pour gérer les favoris, il suffit de passer la souris sur l'un d'eux. Deux icô
 
 \begin{figure}[H]
     \includegraphics[width=\textwidth,height=\textheight,keepaspectratio]{images/client/gestion-favorite.png}
-    \caption[SourceCode : gestion des favoris]{Gestion des favoris (mes-favoris/)}
+    \caption[Source Code : gestion des favoris]{Gestion des favoris (mes-favoris/)}
 \end{figure}
 
 \subsubsubsection{Formulaire de création/modification d'un favori}
@@ -376,7 +376,7 @@ Voici les différents champs à remplir pour créer un favori :
 
 \begin{figure}[H]
     \includegraphics[width=\textwidth,height=\textheight,keepaspectratio]{images/client/favorite-form.png}
-    \caption[SourceCode : création/modification des favoris]{Création/modification des favoris (creer-favori ou \_id)}
+    \caption[Source Code : création/modification des favoris]{Création/modification des favoris (creer-favori ou \_id)}
     \centering
 \end{figure}
 
@@ -436,7 +436,7 @@ Ce module est uniquement accessible aux (super-)administrateurs.
          [importer-des-exercices,highlight]
         ]
     \end{forest}
-    \caption[SourceCode : partie administration (URL)]{Partie administration (URL)}
+    \caption[Source Code : partie administration (URL)]{Partie administration (URL)}
 \end{figure}
 
 \subsubsection{La gestion des \glspl{resinfo}}
@@ -462,12 +462,12 @@ Le créateur de la \gls{resinfo}. À ce stade du développement, nous ne pouvons
 
 \subsubsection{L'importation de \glspl{resinfo}}
 
-Améliorer le processus de création de \glspl{resinfo} est une de nos principales préoccupations pour \texttt{SourceCode}. Nous avons alors développé une interface prenant en charge l'importation de \glspl{resinfo}.
+Améliorer le processus de création de \glspl{resinfo} est une de nos principales préoccupations pour \texttt{Source Code}. Nous avons alors développé une interface prenant en charge l'importation de \glspl{resinfo}.
 
 \begin{figure}[H]
     \includegraphics[width=\textwidth,height=\textheight,keepaspectratio]{images/client/import.png}
     \centering
-    \caption[SourceCode : importation des \glspl{resinfo}]{Importation des \glspl{resinfo} (importer-des-exercices)}
+    \caption[Source Code : importation des \glspl{resinfo}]{Importation des \glspl{resinfo} (importer-des-exercices)}
 \end{figure}
 
 Les \glspl{resinfo} doivent être importées avec un fichier JSON respectant un des deux formats que nous vous invitons à consulter :
@@ -488,7 +488,7 @@ L'interface de gestion prévue à cet effet est semblable à celle de la gestion
 
 \subsubsubsection{Statuts des \glspl{tag}}
 
-De la même manière que pour les \glspl{resinfo}, nous proposons un système de statuts pour donner une indication sur l'état d'un \gls{tag} (la figure \ref{pic:stateDiagramForTags} représente ces états sur un diagramme UML). Nous voulons que le système de \glspl{tag} soit évolutif et flexible. Nous laissons donc les utilisateurs de la plateforme ajouter leurs \glspl{resinfo}, mais aussi des propositions de \glspl{tag} afin d'agrandir le vocabulaire de \texttt{SourceCode}.\\
+De la même manière que pour les \glspl{resinfo}, nous proposons un système de statuts pour donner une indication sur l'état d'un \gls{tag} (la figure \ref{pic:stateDiagramForTags} représente ces états sur un diagramme UML). Nous voulons que le système de \glspl{tag} soit évolutif et flexible. Nous laissons donc les utilisateurs de la plateforme ajouter leurs \glspl{resinfo}, mais aussi des propositions de \glspl{tag} afin d'agrandir le vocabulaire de \texttt{Source Code}.\\
 
 Cela passe bien évidemment par la validation des administrateurs, qui agissent de concert pour offrir un vocabulaire contrôlé aux utilisateurs, évoluant ainsi en fonction des besoins (cf. analyse bibliographique en annexe \ref{annexe:AnalyseBiblio}).
 
@@ -513,7 +513,7 @@ Voici la liste des différents statuts que peut prendre un \gls{tag} :
     \end{itemize}
 \end{itemize}
 
-La suppression physique d'un \gls{tag} est possible, mais elle est réservée au super-administrateur car c'est une opération irréversible. C'est pour cela que l'existence d'un statut "obsolète" a été mis en place : garder une trace sur l'évolution du vocabulaire de \texttt{SourceCode}.
+La suppression physique d'un \gls{tag} est possible, mais elle est réservée au super-administrateur car c'est une opération irréversible. C'est pour cela que l'existence d'un statut "obsolète" a été mis en place : garder une trace sur l'évolution du vocabulaire de \texttt{Source Code}.
 
 \subsubsubsection{Création/modification de \glspl{tag}}
 
@@ -533,7 +533,7 @@ La gestion des \glspl{tagCat} se limite uniquement à la modification du titre o
 
 \subsubsection{La gestion des utilisateurs}
 
-Les administrateurs ont accès à la liste de tout type d'utilisateur ayant un compte enregistré sur \texttt{SourceCode}. Ils peuvent accéder aux informations suivantes :
+Les administrateurs ont accès à la liste de tout type d'utilisateur ayant un compte enregistré sur \texttt{Source Code}. Ils peuvent accéder aux informations suivantes :
 
 \begin{itemize}
     \item Le nom de l'utilisateur

--- a/sections/chapters/solution/divers/index.tex
+++ b/sections/chapters/solution/divers/index.tex
@@ -2,7 +2,7 @@
 \section{Divers}
 \label{chapter:solutionDivers}
 
-Dans cette section, nous aborderons quelques éléments secondaires de \texttt{SourceCode}.
+Dans cette section, nous aborderons quelques éléments secondaires de \texttt{Source Code}.
 En effet, en dehors du développement, il existe bien d'autres facettes importantes du cycle de vie\footnote{
     En anglais, ce terme est connu sous le nom de "software lifecycle". (\url{https://web.maths.unsw.edu.au/~lafaye/CCM/genie-logiciel/cycle-de-vie.htm})
 } d'un logiciel : le \gls{deploiement} / la \gls{maintenance}  ...
@@ -68,12 +68,12 @@ Voici un récapitulatif des concepts clés :
 Nous avons ainsi découpé notre application en 3 images\footnote{
     Elles sont disponibles sur Docker Hub (\url{https://hub.docker.com/}) 
     et générées sur base de fichiers Dockerfile, présents dans chaque repository Github de code.
-    Notons enfin la présence dans le repository miscellaneous de fichiers docker-compose-***.yml pour déployer automatiquement l'entièreté de \texttt{SourceCode} avec Docker Compose, en fonction de l'environnement souhaité (plus d'informations dans le README.MD).
+    Notons enfin la présence dans le repository miscellaneous de fichiers docker-compose-***.yml pour déployer automatiquement l'entièreté de \texttt{Source Code} avec Docker Compose, en fonction de l'environnement souhaité (plus d'informations dans le README.MD).
 } :
 
 \begin{itemize}[nosep,noitemsep,topsep=0pt,partopsep=0pt,after=\vspace*{2pt}]
-    \item sourcecode-front : le \gls{frontend} de \texttt{SourceCode}
-    \item sourcecode\_api : le \gls{backend} de \texttt{SourceCode}
+    \item sourcecode-front : le \gls{frontend} de \texttt{Source Code}
+    \item sourcecode\_api : le \gls{backend} de \texttt{Source Code}
     \item sourcecode-postgres : une base de données en Postgresql, contenant des données extraites par le \Gls{cli}, pour la démonstration de notre solution (cf. section \ref{section:validation})
 \end{itemize}
 


### PR DESCRIPTION
@dewita As the title of the thesis (and website) uses "Source Code", it might be not coherent to use "SourceCode" so I fixed it